### PR TITLE
Use Oracle JDK 8 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: java
+jdk: oraclejdk8


### PR DESCRIPTION
Use Oracle JDK 8 for builds on Travis

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hawaiistatedigitalarchives/pid-webservice/29)

<!-- Reviewable:end -->
